### PR TITLE
feat: show mood-based images for recommendations

### DIFF
--- a/src/utils/mockData.ts
+++ b/src/utils/mockData.ts
@@ -1,8 +1,9 @@
+import { getMoodImage } from "./moodImages";
+
 interface MockRecommendation {
   name: string;
   address: string;
   reason: string;
-  imageUrl: string;
   mapsUrl: string;
   openHours: string;
   distance: string;
@@ -14,7 +15,6 @@ const moodRecommendations: Record<string, MockRecommendation[]> = {
       name: "Zilker Botanical Garden",
       address: "2220 Barton Springs Rd, Austin, TX",
       reason: "Walking beats overthinking",
-      imageUrl: "/lovable-uploads/490baa65-3ec1-4eea-83ad-b1f38758491d.png",
       mapsUrl: "https://maps.apple.com/?q=Zilker+Botanical+Garden",
       openHours: "Open until 7:00 PM",
       distance: "1.2 miles"
@@ -23,7 +23,6 @@ const moodRecommendations: Record<string, MockRecommendation[]> = {
       name: "Town Lake Trail",
       address: "S 1st St & Riverside Dr, Austin, TX",
       reason: "Movement is medicine for restless souls",
-      imageUrl: "/lovable-uploads/490baa65-3ec1-4eea-83ad-b1f38758491d.png",
       mapsUrl: "https://maps.apple.com/?q=Town+Lake+Trail+Austin",
       openHours: "Open 24 hours",
       distance: "0.8 miles"
@@ -34,7 +33,6 @@ const moodRecommendations: Record<string, MockRecommendation[]> = {
       name: "Sugar Mama's Bakeshop",
       address: "1905 S 1st St, Austin, TX",
       reason: "Sadness + cake = science",
-      imageUrl: "/lovable-uploads/490baa65-3ec1-4eea-83ad-b1f38758491d.png",
       mapsUrl: "https://maps.apple.com/?q=Sugar+Mamas+Bakeshop",
       openHours: "Open until 10:00 PM",
       distance: "1.5 miles"
@@ -43,7 +41,6 @@ const moodRecommendations: Record<string, MockRecommendation[]> = {
       name: "BookPeople",
       address: "603 N Lamar Blvd, Austin, TX",
       reason: "Books understand your feelings",
-      imageUrl: "/lovable-uploads/490baa65-3ec1-4eea-83ad-b1f38758491d.png",
       mapsUrl: "https://maps.apple.com/?q=BookPeople+Austin",
       openHours: "Open until 9:00 PM",
       distance: "2.1 miles"
@@ -54,7 +51,6 @@ const moodRecommendations: Record<string, MockRecommendation[]> = {
       name: "The Oasis on Lake Travis",
       address: "6550 Comanche Trail, Austin, TX",
       reason: "Sunsets were made for romance",
-      imageUrl: "/lovable-uploads/490baa65-3ec1-4eea-83ad-b1f38758491d.png",
       mapsUrl: "https://maps.apple.com/?q=The+Oasis+Lake+Travis",
       openHours: "Open until 11:00 PM",
       distance: "18.3 miles"
@@ -65,7 +61,6 @@ const moodRecommendations: Record<string, MockRecommendation[]> = {
       name: "Umlauf Sculpture Garden",
       address: "605 Azie Morton Rd, Austin, TX",
       reason: "Art soothes anxious minds",
-      imageUrl: "/lovable-uploads/490baa65-3ec1-4eea-83ad-b1f38758491d.png",
       mapsUrl: "https://maps.apple.com/?q=Umlauf+Sculpture+Garden",
       openHours: "Open until 5:00 PM",
       distance: "3.2 miles"
@@ -76,7 +71,6 @@ const moodRecommendations: Record<string, MockRecommendation[]> = {
       name: "Rainey Street",
       address: "Rainey St, Austin, TX",
       reason: "Life's good moments deserve toasts",
-      imageUrl: "/lovable-uploads/490baa65-3ec1-4eea-83ad-b1f38758491d.png",
       mapsUrl: "https://maps.apple.com/?q=Rainey+Street+Austin",
       openHours: "Open until 2:00 AM",
       distance: "0.5 miles"
@@ -87,7 +81,6 @@ const moodRecommendations: Record<string, MockRecommendation[]> = {
       name: "Pinballz Arcade",
       address: "8940 Research Blvd, Austin, TX",
       reason: "Boredom is just unchallenged potential",
-      imageUrl: "/lovable-uploads/490baa65-3ec1-4eea-83ad-b1f38758491d.png",
       mapsUrl: "https://maps.apple.com/?q=Pinballz+Arcade+Austin",
       openHours: "Open until midnight",
       distance: "12.4 miles"
@@ -98,7 +91,6 @@ const moodRecommendations: Record<string, MockRecommendation[]> = {
       name: "6th Street",
       address: "E 6th St, Austin, TX",
       reason: "Energy needs an outlet",
-      imageUrl: "/lovable-uploads/490baa65-3ec1-4eea-83ad-b1f38758491d.png",
       mapsUrl: "https://maps.apple.com/?q=6th+Street+Austin",
       openHours: "Open until 2:00 AM",
       distance: "1.1 miles"
@@ -109,7 +101,6 @@ const moodRecommendations: Record<string, MockRecommendation[]> = {
       name: "Barton Springs Pool",
       address: "2201 Barton Springs Rd, Austin, TX",
       reason: "Adventure starts with a cold plunge",
-      imageUrl: "/lovable-uploads/490baa65-3ec1-4eea-83ad-b1f38758491d.png",
       mapsUrl: "https://maps.apple.com/?q=Barton+Springs+Pool",
       openHours: "Open until 9:00 PM",
       distance: "2.8 miles"
@@ -120,7 +111,6 @@ const moodRecommendations: Record<string, MockRecommendation[]> = {
       name: "The Continental Club",
       address: "1315 S Congress Ave, Austin, TX",
       reason: "Where old souls find their soundtrack",
-      imageUrl: "/lovable-uploads/490baa65-3ec1-4eea-83ad-b1f38758491d.png",
       mapsUrl: "https://maps.apple.com/?q=Continental+Club+Austin",
       openHours: "Open until 2:00 AM",
       distance: "2.3 miles"
@@ -131,7 +121,6 @@ const moodRecommendations: Record<string, MockRecommendation[]> = {
       name: "Amy's Ice Cream",
       address: "1012 W 6th St, Austin, TX",
       reason: "Life's too short for predictable desserts",
-      imageUrl: "/lovable-uploads/490baa65-3ec1-4eea-83ad-b1f38758491d.png",
       mapsUrl: "https://maps.apple.com/?q=Amys+Ice+Cream+6th+Street",
       openHours: "Open until 11:00 PM",
       distance: "1.7 miles"
@@ -140,7 +129,6 @@ const moodRecommendations: Record<string, MockRecommendation[]> = {
       name: "South by Sea",
       address: "2024 E 6th St, Austin, TX",
       reason: "Sometimes you need unexpected oysters",
-      imageUrl: "/lovable-uploads/490baa65-3ec1-4eea-83ad-b1f38758491d.png",
       mapsUrl: "https://maps.apple.com/?q=South+by+Sea+Austin",
       openHours: "Open until 10:00 PM",
       distance: "1.9 miles"
@@ -161,14 +149,18 @@ const moodLabels: Record<string, { label: string; emoji: string }> = {
   surprise: { label: "Surprise Me", emoji: "🎲" }
 };
 
-export const getRecommendation = (mood: string, reroll: boolean = false): MockRecommendation & { mood: string; moodEmoji: string } => {
+export const getRecommendation = (
+  mood: string,
+  reroll: boolean = false
+): MockRecommendation & { mood: string; moodEmoji: string; imageUrl: string } => {
   const recommendations = moodRecommendations[mood] || moodRecommendations.surprise;
   const randomIndex = reroll ? 1 : 0; // Simple reroll logic - use second option if available
   const rec = recommendations[Math.min(randomIndex, recommendations.length - 1)];
   const moodInfo = moodLabels[mood] || moodLabels.surprise;
-  
+
   return {
     ...rec,
+    imageUrl: getMoodImage(mood),
     mood: moodInfo.label,
     moodEmoji: moodInfo.emoji
   };

--- a/src/utils/moodImages.ts
+++ b/src/utils/moodImages.ts
@@ -1,0 +1,139 @@
+const moodKeywords: Record<string, string[]> = {
+  restless: [
+    "restless",
+    "city-night",
+    "wander",
+    "stirring",
+    "busy-street",
+    "jogging",
+    "nightlife",
+    "crowd",
+    "movement",
+    "travel"
+  ],
+  sad: [
+    "rain",
+    "lonely",
+    "melancholy",
+    "grey",
+    "tears",
+    "overcast",
+    "solitude",
+    "blue",
+    "pensive",
+    "reflection"
+  ],
+  romantic: [
+    "romance",
+    "love",
+    "couple",
+    "valentine",
+    "candlelight",
+    "date",
+    "sunset",
+    "flowers",
+    "kiss",
+    "together"
+  ],
+  anxious: [
+    "calm",
+    "meditation",
+    "serene",
+    "peace",
+    "breath",
+    "yoga",
+    "nature",
+    "water",
+    "relax",
+    "balance"
+  ],
+  celebratory: [
+    "party",
+    "celebration",
+    "cheers",
+    "fireworks",
+    "confetti",
+    "birthday",
+    "toast",
+    "festival",
+    "crowd",
+    "laugh"
+  ],
+  bored: [
+    "bored",
+    "waiting",
+    "empty",
+    "minimal",
+    "monotony",
+    "nothing",
+    "alone",
+    "idle",
+    "stare",
+    "meh"
+  ],
+  energetic: [
+    "running",
+    "dance",
+    "workout",
+    "jump",
+    "music",
+    "festival",
+    "sports",
+    "hiking",
+    "party",
+    "active"
+  ],
+  adventurous: [
+    "adventure",
+    "hiking",
+    "mountain",
+    "explore",
+    "roadtrip",
+    "camping",
+    "trail",
+    "wanderlust",
+    "kayak",
+    "cliff"
+  ],
+  nostalgic: [
+    "vintage",
+    "retro",
+    "old",
+    "nostalgia",
+    "film",
+    "classic",
+    "antique",
+    "memories",
+    "record",
+    "timeless"
+  ],
+  surprise: [
+    "surprise",
+    "confetti",
+    "unexpected",
+    "random",
+    "mystery",
+    "gift",
+    "wonder",
+    "shock",
+    "wow",
+    "awe"
+  ]
+};
+
+export const moodImages: Record<string, string[]> = Object.fromEntries(
+  Object.entries(moodKeywords).map(([mood, keywords]) => [
+    mood,
+    keywords.map((keyword, index) =>
+      `https://source.unsplash.com/featured/400x300?${encodeURIComponent(keyword)}&sig=${index}`
+    )
+  ])
+);
+
+export const getMoodImage = (mood: string): string => {
+  const images = moodImages[mood] || moodImages.surprise;
+  const index = Math.floor(Math.random() * images.length);
+  return images[index];
+};
+
+export default moodImages;

--- a/src/utils/placesService.ts
+++ b/src/utils/placesService.ts
@@ -1,4 +1,5 @@
 import { UserLocation, getDistanceInMiles } from "./location";
+import { getMoodImage } from "./moodImages";
 
 interface Place {
   name: string;
@@ -192,7 +193,7 @@ export const getLocationAwareRecommendation = async (
     name: selectedPlace.name,
     address: fullAddress,
     reason: reasons[reasonIndex],
-    imageUrl: "/lovable-uploads/490baa65-3ec1-4eea-83ad-b1f38758491d.png",
+    imageUrl: getMoodImage(mood),
     mapsUrl: `https://maps.apple.com/?q=${encodeURIComponent(selectedPlace.name + " " + fullAddress)}`,
     mood: moodInfo.label,
     moodEmoji: moodInfo.emoji,


### PR DESCRIPTION
## Summary
- add mood image keyword map and helper
- use mood-based images in location-aware recommendations
- include mood-specific images in mock recommendations

## Testing
- ❌ `npm run lint` (fails: An interface declaring no members is equivalent to its supertype, A `require()` style import is forbidden)
- ✅ `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a14a39eee08328a4a922d6a1920d7b