### PR TITLE
Use Mailtrap API for feedback emails

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -11,8 +11,7 @@
         "cors": "^2.8.5",
         "dotenv": "^16.3.1",
         "express": "^4.18.2",
-        "express-rate-limit": "^7.1.5",
-        "nodemailer": "^6.9.7"
+        "express-rate-limit": "^7.1.5"
       },
       "devDependencies": {
         "nodemon": "^3.0.2"
@@ -773,15 +772,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/nodemailer": {
-      "version": "6.10.1",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.1.tgz",
-      "integrity": "sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA==",
-      "license": "MIT-0",
-      "engines": {
-        "node": ">=6.0.0"
       }
     },
     "node_modules/nodemon": {

--- a/server/package.json
+++ b/server/package.json
@@ -12,7 +12,6 @@
     "express": "^4.18.2",
     "cors": "^2.8.5",
     "dotenv": "^16.3.1",
-    "nodemailer": "^6.9.7",
     "express-rate-limit": "^7.1.5"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- send feedback emails via Mailtrap HTTP API
- remove nodemailer dependency from server

## Testing
- `curl --location --request POST 'https://send.api.mailtrap.io/api/send' --header 'Authorization: Bearer fd760fb49453ec12eaa5a369a7d2073a' --header 'Content-Type: application/json' --data-raw '{"from":{"email":"hello@demomailtrap.co","name":"Mailtrap Test"},"to":[{"email":"shellshock1947@gmail.com"}],"subject":"Test after server change","text":"Hello again","category":"Integration Test"}'`
- `curl -s -X POST http://localhost:3001/api/feedback -H 'Content-Type: application/json' -d '{"name":"Test User","email":"test@example.com","message":"Hello from test"}'` *(fails: ENETUNREACH)*
- `npm run lint` *(fails: 3 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a1962303b88328909995e63f74a19b