### PR TITLE
feat: add animated mood tiles and surprise picker

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "@radix-ui/react-toggle-group": "^1.1.10",
         "@radix-ui/react-tooltip": "^1.2.7",
         "@tanstack/react-query": "^5.83.0",
+        "canvas-confetti": "^1.9.3",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
@@ -3475,6 +3476,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/canvas-confetti": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/canvas-confetti/-/canvas-confetti-1.9.3.tgz",
+      "integrity": "sha512-rFfTURMvmVEX1gyXFgn5QMn81bYk70qa0HLzcIOSVEyl57n6o9ItHeBtUSWdvKAPY0xlvBHno4/v3QPrT83q9g==",
+      "license": "ISC",
+      "funding": {
+        "type": "donate",
+        "url": "https://www.paypal.me/kirilvatev"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@radix-ui/react-toggle-group": "^1.1.10",
     "@radix-ui/react-tooltip": "^1.2.7",
     "@tanstack/react-query": "^5.83.0",
+    "canvas-confetti": "^1.9.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",

--- a/src/components/LoadingRecommendation.tsx
+++ b/src/components/LoadingRecommendation.tsx
@@ -3,17 +3,18 @@ import { Card } from "@/components/ui/card";
 
 interface LoadingRecommendationProps {
   mood: string;
-  moodEmoji: string;
+  moodImage: string;
   userLocation?: string;
 }
 
-export const LoadingRecommendation = ({ mood, moodEmoji, userLocation }: LoadingRecommendationProps) => {
+export const LoadingRecommendation = ({ mood, moodImage, userLocation }: LoadingRecommendationProps) => {
   return (
     <div className="min-h-screen bg-background flex flex-col items-center justify-center p-6">
       <div className="max-w-md w-full space-y-6">
         <div className="text-center space-y-2">
-          <p className="text-lg text-muted-foreground">
-            Your Mood: {moodEmoji} {mood}
+          <p className="text-lg text-muted-foreground flex items-center gap-2 justify-center">
+            <img src={`/vibes/${moodImage}`} alt={mood} className="w-6 h-6" />
+            <span>Your Mood: {mood}</span>
           </p>
           {userLocation && (
             <p className="text-sm text-muted-foreground">

--- a/src/components/MoodBoard.tsx
+++ b/src/components/MoodBoard.tsx
@@ -1,21 +1,85 @@
+import { useEffect, useRef, useState } from "react";
+import confetti from "canvas-confetti";
 import { Button } from "@/components/ui/button";
 
 interface Mood {
   id: string;
   label: string;
-  emoji: string;
+  image: string;
+  tagline: string;
+  colors: string[];
 }
 
 const moods: Mood[] = [
-  { id: "restless", label: "Restless", emoji: "😵" },
-  { id: "sad", label: "Sad", emoji: "😔" },
-  { id: "romantic", label: "Romantic", emoji: "❤️" },
-  { id: "anxious", label: "Anxious", emoji: "🤯" },
-  { id: "celebratory", label: "Celebratory", emoji: "🎉" },
-  { id: "bored", label: "Bored", emoji: "😴" },
-  { id: "energetic", label: "Energetic", emoji: "⚡" },
-  { id: "adventurous", label: "Adventurous", emoji: "🗺️" },
-  { id: "nostalgic", label: "Nostalgic", emoji: "🕰️" },
+  {
+    id: "restless",
+    label: "Restless",
+    image: "restless.png",
+    tagline: "Burn energy, not brain cells.",
+    colors: ["#FFB74D", "#FF8A65"],
+  },
+  {
+    id: "sad",
+    label: "Sad",
+    image: "sad.png",
+    tagline: "Cake therapy, scientifically proven.",
+    colors: ["#4FC3F7", "#81D4FA"],
+  },
+  {
+    id: "romantic",
+    label: "Romantic",
+    image: "romantic.png",
+    tagline: "Love is in the air...and also fries.",
+    colors: ["#F06292", "#EF5350"],
+  },
+  {
+    id: "anxious",
+    label: "Anxious",
+    image: "anxious.png",
+    tagline: "Breathe in, chill out, snack on.",
+    colors: ["#BA68C8", "#9575CD"],
+  },
+  {
+    id: "celebratory",
+    label: "Celebratory",
+    image: "celebratory.png",
+    tagline: "Pop fizz clink—it's party time.",
+    colors: ["#FFD54F", "#FFB300"],
+  },
+  {
+    id: "bored",
+    label: "Bored",
+    image: "bored.png",
+    tagline: "Escape the void, one bite at a time.",
+    colors: ["#90A4AE", "#B0BEC5"],
+  },
+  {
+    id: "energetic",
+    label: "Energetic",
+    image: "energetic.png",
+    tagline: "Fuel the hype train!",
+    colors: ["#81C784", "#66BB6A"],
+  },
+  {
+    id: "adventurous",
+    label: "Adventurous",
+    image: "adventorous.png",
+    tagline: "Because Netflix can wait.",
+    colors: ["#4DB6AC", "#26A69A"],
+  },
+  {
+    id: "nostalgic",
+    label: "Nostalgic",
+    image: "nostalgic.png",
+    tagline: "Old-school fun for modern moods.",
+    colors: ["#FFAB91", "#FF8A65"],
+  },
+];
+
+const wildPicks = [
+  "Feeling nostalgic? Here’s a retro arcade near you.",
+  "Craving chaos? There's a carnival in town.",
+  "Need a laugh? Try this comedy club tonight.",
 ];
 
 interface MoodBoardProps {
@@ -23,9 +87,63 @@ interface MoodBoardProps {
 }
 
 export const MoodBoard = ({ onMoodSelect }: MoodBoardProps) => {
+  const [surpriseRolling, setSurpriseRolling] = useState(false);
+  const [displayMood, setDisplayMood] = useState<Mood | null>(null);
+  const [zoomMood, setZoomMood] = useState<Mood | null>(null);
+  const rollingRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (rollingRef.current) clearInterval(rollingRef.current);
+    };
+  }, []);
+
+  const triggerConfetti = (colors: string[]) => {
+    confetti({ particleCount: 80, spread: 60, colors });
+  };
+
+  const handleMood = (mood: Mood) => {
+    triggerConfetti(mood.colors);
+    setZoomMood(mood);
+    setTimeout(() => onMoodSelect(mood.id), 600);
+  };
+
+  const handleSurprise = () => {
+    setSurpriseRolling(true);
+    let i = 0;
+    rollingRef.current = window.setInterval(() => {
+      setDisplayMood(moods[i % moods.length]);
+      i++;
+    }, 100);
+
+    setTimeout(() => {
+      if (rollingRef.current) clearInterval(rollingRef.current);
+      const mood = moods[Math.floor(Math.random() * moods.length)];
+      setDisplayMood(mood);
+      setSurpriseRolling(false);
+      handleMood(mood);
+    }, 2000);
+  };
+
+  const todayPick = wildPicks[new Date().getDate() % wildPicks.length];
+
   return (
     <div className="min-h-screen bg-background flex flex-col items-center justify-center p-6">
       <div className="max-w-lg w-full space-y-8">
+      {zoomMood && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center">
+          <div className="zoom-anim">
+            <div className="flip-card-front h-20 w-32 bg-gradient-mood text-center p-4 rounded-xl shadow-mood flex flex-col items-center justify-center">
+              <img
+                src={`/vibes/${zoomMood.image}`}
+                alt={zoomMood.label}
+                className="w-8 h-8 mb-1"
+              />
+              <span className="text-sm font-medium">{zoomMood.label}</span>
+            </div>
+          </div>
+        </div>
+      )}
         <header className="text-center space-y-4">
           <h1 className="text-5xl font-extrabold tracking-tight text-foreground">
             Just One Place
@@ -40,30 +158,67 @@ export const MoodBoard = ({ onMoodSelect }: MoodBoardProps) => {
             Pick your vibe 👇
           </h2>
           <p className="text-muted-foreground text-lg">
-            We'll find you the perfect spot
+            We’ll boss you around and send you somewhere cool 😎
           </p>
         </div>
 
         <div className="grid grid-cols-3 gap-4">
           {moods.map((mood) => (
-            <Button
+            <div
               key={mood.id}
-              variant="mood"
-              onClick={() => onMoodSelect(mood.id)}
-              className="h-20 flex-col p-4 text-center"
+              className="flip-card h-20"
+              onClick={() => handleMood(mood)}
             >
-              <span className="text-2xl mb-1">{mood.emoji}</span>
-              <span className="text-sm font-medium">{mood.label}</span>
-            </Button>
+              <div className="flip-card-inner">
+                <div className="flip-card-front bg-gradient-mood text-center p-4 rounded-xl shadow-mood flex flex-col items-center justify-center">
+                  <img
+                    src={`/vibes/${mood.image}`}
+                    alt={mood.label}
+                    className="w-8 h-8 mb-1"
+                  />
+                  <span className="text-sm font-medium">{mood.label}</span>
+                </div>
+                <div className="flip-card-back bg-gradient-mood text-center p-4 rounded-xl shadow-mood flex flex-col items-center justify-center">
+                  <span className="text-xs font-medium px-2">
+                    {mood.tagline}
+                  </span>
+                </div>
+              </div>
+            </div>
           ))}
+        </div>
+
+        <div className="text-center space-y-3">
+          <h3 className="text-2xl font-bold">Today's Wild Pick</h3>
+          <div className="bg-gradient-mood p-4 rounded-xl shadow-mood text-sm font-medium rotate-[2deg]">
+            {todayPick}
+          </div>
         </div>
 
         <Button
           variant="action"
-          onClick={() => onMoodSelect("surprise")}
-          className="w-full h-14 text-lg"
+          onClick={handleSurprise}
+          className="relative w-full h-14 text-lg overflow-hidden"
         >
-          🎲 Surprise Me
+          {surpriseRolling && (
+            <img
+              src="/vibes/surprise.png"
+              alt="dice"
+              className="dice-animation absolute top-1/2 -translate-y-1/2"
+            />
+          )}
+          <div className="flex items-center gap-2">
+            {displayMood ? (
+              <img
+                src={`/vibes/${displayMood.image}`}
+                alt={displayMood.label}
+                className="w-6 h-6"
+              />
+            ) : (
+              <img src="/vibes/surprise.png" alt="surprise" className="w-6 h-6" />
+            )}
+            <span>{displayMood ? displayMood.label : "Surprise Me"}</span>
+          </div>
         </Button>
 
         <div className="text-center space-y-1">
@@ -71,7 +226,7 @@ export const MoodBoard = ({ onMoodSelect }: MoodBoardProps) => {
             No endless lists. Just one perfect recommendation.
           </p>
           <p className="text-xs text-muted-foreground italic">
-            Warning: side effects may include spontaneous fun.
+            Side effects may include fun, unexpected adventures, and sugar highs.
           </p>
         </div>
       </div>

--- a/src/components/RecommendationCard.tsx
+++ b/src/components/RecommendationCard.tsx
@@ -8,7 +8,7 @@ interface Recommendation {
   imageUrl: string;
   mapsUrl: string;
   mood: string;
-  moodEmoji: string;
+  moodImage: string;
   openHours: string;
   distance: string;
 }
@@ -34,8 +34,9 @@ export const RecommendationCard = ({
     <div className="min-h-screen bg-background flex flex-col items-center justify-center p-6">
       <div className="max-w-md w-full space-y-6">
         <div className="text-center">
-          <p className="text-lg text-muted-foreground mb-2">
-            Your Mood: {recommendation.moodEmoji} {recommendation.mood}
+          <p className="text-lg text-muted-foreground mb-2 flex items-center gap-2 justify-center">
+            <img src={`/vibes/${recommendation.moodImage}`} alt={recommendation.mood} className="w-6 h-6" />
+            <span>Your Mood: {recommendation.mood}</span>
           </p>
         </div>
 

--- a/src/index.css
+++ b/src/index.css
@@ -117,7 +117,67 @@ All colors MUST be HSL.
     @apply border-border;
   }
 
-  body {
+body {
     @apply bg-background text-foreground;
+  }
+}
+
+/* custom animations for mood board */
+.flip-card {
+  perspective: 1000px;
+}
+
+.flip-card-inner {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  transition: transform 0.6s;
+  transform-style: preserve-3d;
+}
+
+.flip-card:hover .flip-card-inner {
+  transform: rotateY(180deg);
+}
+
+.flip-card-front,
+.flip-card-back {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  backface-visibility: hidden;
+  border-radius: var(--radius);
+}
+
+.flip-card-back {
+  transform: rotateY(180deg);
+}
+
+.dice-animation {
+  animation: roll 2s linear forwards;
+}
+
+@keyframes roll {
+  0% {
+    left: -10%;
+    transform: rotate(0deg);
+  }
+  100% {
+    left: 110%;
+    transform: rotate(720deg);
+  }
+}
+
+.zoom-anim {
+  animation: zoom 0.6s forwards;
+}
+
+@keyframes zoom {
+  from {
+    transform: scale(1);
+    opacity: 1;
+  }
+  to {
+    transform: scale(20);
+    opacity: 0;
   }
 }

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -124,17 +124,17 @@ const Index = () => {
       />
     );
   } else if (state === "loading") {
-    const moodLabels: Record<string, { label: string; emoji: string }> = {
-      restless: { label: "Restless", emoji: "😵" },
-      sad: { label: "Sad", emoji: "😔" },
-      romantic: { label: "Romantic", emoji: "❤️" },
-      anxious: { label: "Anxious", emoji: "🤯" },
-      celebratory: { label: "Celebratory", emoji: "🎉" },
-      bored: { label: "Bored", emoji: "😴" },
-      energetic: { label: "Energetic", emoji: "⚡" },
-      adventurous: { label: "Adventurous", emoji: "🗺️" },
-      nostalgic: { label: "Nostalgic", emoji: "🕰️" },
-      surprise: { label: "Surprise Me", emoji: "🎲" }
+    const moodLabels: Record<string, { label: string; image: string }> = {
+      restless: { label: "Restless", image: "restless.png" },
+      sad: { label: "Sad", image: "sad.png" },
+      romantic: { label: "Romantic", image: "romantic.png" },
+      anxious: { label: "Anxious", image: "anxious.png" },
+      celebratory: { label: "Celebratory", image: "celebratory.png" },
+      bored: { label: "Bored", image: "bored.png" },
+      energetic: { label: "Energetic", image: "energetic.png" },
+      adventurous: { label: "Adventurous", image: "adventorous.png" },
+      nostalgic: { label: "Nostalgic", image: "nostalgic.png" },
+      surprise: { label: "Surprise Me", image: "surprise.png" }
     };
 
     const moodInfo = moodLabels[selectedMood] || moodLabels.surprise;
@@ -142,7 +142,7 @@ const Index = () => {
     content = (
       <LoadingRecommendation
         mood={moodInfo.label}
-        moodEmoji={moodInfo.emoji}
+        moodImage={moodInfo.image}
         userLocation={
           userLocation?.city && userLocation?.state
             ? `${userLocation.city}, ${userLocation.state}`

--- a/src/utils/mockData.ts
+++ b/src/utils/mockData.ts
@@ -148,20 +148,20 @@ const moodRecommendations: Record<string, MockRecommendation[]> = {
   ]
 };
 
-const moodLabels: Record<string, { label: string; emoji: string }> = {
-  restless: { label: "Restless", emoji: "😵" },
-  sad: { label: "Sad", emoji: "😔" },
-  romantic: { label: "Romantic", emoji: "❤️" },
-  anxious: { label: "Anxious", emoji: "🤯" },
-  celebratory: { label: "Celebratory", emoji: "🎉" },
-  bored: { label: "Bored", emoji: "😴" },
-  energetic: { label: "Energetic", emoji: "⚡" },
-  adventurous: { label: "Adventurous", emoji: "🗺️" },
-  nostalgic: { label: "Nostalgic", emoji: "🕰️" },
-  surprise: { label: "Surprise Me", emoji: "🎲" }
+const moodLabels: Record<string, { label: string; image: string }> = {
+  restless: { label: "Restless", image: "restless.png" },
+  sad: { label: "Sad", image: "sad.png" },
+  romantic: { label: "Romantic", image: "romantic.png" },
+  anxious: { label: "Anxious", image: "anxious.png" },
+  celebratory: { label: "Celebratory", image: "celebratory.png" },
+  bored: { label: "Bored", image: "bored.png" },
+  energetic: { label: "Energetic", image: "energetic.png" },
+  adventurous: { label: "Adventurous", image: "adventorous.png" },
+  nostalgic: { label: "Nostalgic", image: "nostalgic.png" },
+  surprise: { label: "Surprise Me", image: "surprise.png" }
 };
 
-export const getRecommendation = (mood: string, reroll: boolean = false): MockRecommendation & { mood: string; moodEmoji: string } => {
+export const getRecommendation = (mood: string, reroll: boolean = false): MockRecommendation & { mood: string; moodImage: string } => {
   const recommendations = moodRecommendations[mood] || moodRecommendations.surprise;
   const randomIndex = reroll ? 1 : 0; // Simple reroll logic - use second option if available
   const rec = recommendations[Math.min(randomIndex, recommendations.length - 1)];
@@ -170,6 +170,6 @@ export const getRecommendation = (mood: string, reroll: boolean = false): MockRe
   return {
     ...rec,
     mood: moodInfo.label,
-    moodEmoji: moodInfo.emoji
+    moodImage: moodInfo.image
   };
 };

--- a/src/utils/placesService.ts
+++ b/src/utils/placesService.ts
@@ -106,7 +106,7 @@ export interface LocationAwareRecommendation {
   imageUrl: string;
   mapsUrl: string;
   mood: string;
-  moodEmoji: string;
+  moodImage: string;
   openHours: string;
   distance: string;
   userLocation: string;
@@ -172,17 +172,17 @@ export const getLocationAwareRecommendation = async (
     : `${selectedPlace.address}, ${locationText}`;
 
   // Get mood info
-  const moodLabels: Record<string, { label: string; emoji: string }> = {
-    restless: { label: "Restless", emoji: "😵" },
-    sad: { label: "Sad", emoji: "😔" },
-    romantic: { label: "Romantic", emoji: "❤️" },
-    anxious: { label: "Anxious", emoji: "🤯" },
-    celebratory: { label: "Celebratory", emoji: "🎉" },
-    bored: { label: "Bored", emoji: "😴" },
-    energetic: { label: "Energetic", emoji: "⚡" },
-    adventurous: { label: "Adventurous", emoji: "🗺️" },
-    nostalgic: { label: "Nostalgic", emoji: "🕰️" },
-    surprise: { label: "Surprise Me", emoji: "🎲" }
+  const moodLabels: Record<string, { label: string; image: string }> = {
+    restless: { label: "Restless", image: "restless.png" },
+    sad: { label: "Sad", image: "sad.png" },
+    romantic: { label: "Romantic", image: "romantic.png" },
+    anxious: { label: "Anxious", image: "anxious.png" },
+    celebratory: { label: "Celebratory", image: "celebratory.png" },
+    bored: { label: "Bored", image: "bored.png" },
+    energetic: { label: "Energetic", image: "energetic.png" },
+    adventurous: { label: "Adventurous", image: "adventorous.png" },
+    nostalgic: { label: "Nostalgic", image: "nostalgic.png" },
+    surprise: { label: "Surprise Me", image: "surprise.png" }
   };
 
   const moodInfo = moodLabels[mood] || moodLabels.surprise;
@@ -195,7 +195,7 @@ export const getLocationAwareRecommendation = async (
     imageUrl: "/lovable-uploads/490baa65-3ec1-4eea-83ad-b1f38758491d.png",
     mapsUrl: `https://maps.apple.com/?q=${encodeURIComponent(selectedPlace.name + " " + fullAddress)}`,
     mood: moodInfo.label,
-    moodEmoji: moodInfo.emoji,
+    moodImage: moodInfo.image,
     openHours: selectedPlace.openHours || "Check hours online",
     distance: distanceText,
     userLocation: locationText


### PR DESCRIPTION
## Summary
- flip mood cards with taglines, confetti bursts, and zoom transition
- add slot-machine style Surprise Me button with dice animation
- switch to custom vibe icons and add daily "Wild Pick"

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: @typescript-eslint/no-empty-object-type, @typescript-eslint/no-require-imports)


------
https://chatgpt.com/codex/tasks/task_e_68a19f2de94883289fc2017e2034027f