### PR TITLE
Add animated flair and mascot guide to vibe picker

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,6 +16,13 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:site" content="@lovable_dev" />
     <meta name="twitter:image" content="https://lovable.dev/opengraph-image-p98pqg.png" />
+
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Poppins:wght@600;800&display=swap"
+      rel="stylesheet"
+    />
   </head>
 
   <body>

--- a/public/mascot.svg
+++ b/public/mascot.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <circle cx="32" cy="32" r="30" fill="#feca57" />
+  <circle cx="22" cy="26" r="5" fill="#000" />
+  <circle cx="42" cy="26" r="5" fill="#000" />
+  <path d="M22 42c3 4 9 4 12 0" stroke="#000" stroke-width="4" fill="none" stroke-linecap="round" />
+</svg>

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,4 @@
+@import url('https://fonts.googleapis.com/css2?family=Poppins:wght@600;800&display=swap');
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
@@ -118,7 +119,41 @@ All colors MUST be HSL.
   }
 
   body {
-    @apply bg-background text-foreground;
+    @apply text-foreground;
+    background: linear-gradient(120deg, hsl(var(--background)), hsl(var(--accent)), hsl(var(--secondary)));
+    background-size: 400% 400%;
+    animation: backgroundShift 30s ease infinite;
+  }
+
+  h1, h2, h3, h4, h5, h6 {
+    font-family: 'Poppins', sans-serif;
+  }
+}
+
+@keyframes backgroundShift {
+  0% {
+    background-position: 0% 50%;
+  }
+  50% {
+    background-position: 100% 50%;
+  }
+  100% {
+    background-position: 0% 50%;
+  }
+}
+
+.slot-list {
+  display: flex;
+  flex-direction: column;
+}
+
+.slot-animate {
+  animation: slot-roll 1s ease-in-out forwards;
+}
+
+@keyframes slot-roll {
+  to {
+    transform: translateY(calc(var(--items) * -1.5rem));
   }
 }
 

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -18,8 +18,8 @@ export default {
 				'2xl': '1400px'
 			}
 		},
-		extend: {
-			colors: {
+                extend: {
+                        colors: {
 				border: 'hsl(var(--border))',
 				input: 'hsl(var(--input))',
 				ring: 'hsl(var(--ring))',
@@ -69,16 +69,19 @@ export default {
 				'gradient-mood': 'var(--gradient-mood)',
 				'gradient-card': 'var(--gradient-card)'
 			},
-			boxShadow: {
-				'mood': 'var(--shadow-mood)',
-				'card-custom': 'var(--shadow-card)',
-				'button-custom': 'var(--shadow-button)'
-			},
-			borderRadius: {
-				lg: 'var(--radius)',
-				md: 'calc(var(--radius) - 2px)',
-				sm: 'calc(var(--radius) - 4px)'
-			},
+                        boxShadow: {
+                                'mood': 'var(--shadow-mood)',
+                                'card-custom': 'var(--shadow-card)',
+                                'button-custom': 'var(--shadow-button)'
+                        },
+                        fontFamily: {
+                                heading: ['Poppins', 'sans-serif'],
+                        },
+                        borderRadius: {
+                                lg: 'var(--radius)',
+                                md: 'calc(var(--radius) - 2px)',
+                                sm: 'calc(var(--radius) - 4px)'
+                        },
 			keyframes: {
 				'accordion-down': {
 					from: {


### PR DESCRIPTION
## Summary
- animate background with soft gradient and add playful Poppins headings
- introduce rolling “Surprise Me” slot machine, hover icon animations and mascot guide
- highlight daily wild pick with external link and add mascot asset

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a1b43cc5808328a347f8dfb4abfb37