### PR TITLE
Allow manual ZIP entry and keep gradient across flows

### DIFF
--- a/src/components/LoadingRecommendation.tsx
+++ b/src/components/LoadingRecommendation.tsx
@@ -8,7 +8,7 @@ interface LoadingRecommendationProps {
 
 export const LoadingRecommendation = ({ mood, moodImage, userLocation }: LoadingRecommendationProps) => {
   return (
-    <div className="min-h-screen bg-background flex flex-col items-center justify-center p-6">
+    <div className="min-h-screen flex flex-col items-center justify-center p-6">
       <div className="max-w-md w-full space-y-6">
         <div className="text-center space-y-2">
           <p className="text-lg text-muted-foreground flex items-center justify-center gap-2">

--- a/src/components/LocationRequest.tsx
+++ b/src/components/LocationRequest.tsx
@@ -1,21 +1,33 @@
+import { useState, type FormEvent } from "react";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
 import { MapPin, Clock, AlertCircle } from "lucide-react";
 
 interface LocationRequestProps {
   onLocationGranted: () => void;
-  onLocationDenied: () => void;
+  onZipSubmit: (zip: string) => void;
   mood: string;
   error?: string;
 }
 
-export const LocationRequest = ({ onLocationGranted, onLocationDenied, mood, error }: LocationRequestProps) => {
+export const LocationRequest = ({ onLocationGranted, onZipSubmit, mood, error }: LocationRequestProps) => {
+  const [showZipInput, setShowZipInput] = useState(false);
+  const [zip, setZip] = useState("");
+
   const handleRequestLocation = () => {
     navigator.geolocation.getCurrentPosition(
       () => onLocationGranted(),
-      () => onLocationDenied(),
+      () => setShowZipInput(true),
       { enableHighAccuracy: true, timeout: 10000 }
     );
+  };
+
+  const handleZipSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    if (zip.trim()) {
+      onZipSubmit(zip.trim());
+    }
   };
 
   const guideMessages: Record<string, string> = {
@@ -32,7 +44,7 @@ export const LocationRequest = ({ onLocationGranted, onLocationDenied, mood, err
   const guideText = guideMessages[mood] ?? "Ready for an adventure?";
 
   return (
-    <div className="min-h-screen bg-background flex flex-col items-center justify-center p-6">
+    <div className="min-h-screen flex flex-col items-center justify-center p-6">
       <div className="max-w-md w-full space-y-6">
         <div className="flex items-center justify-center gap-2 text-muted-foreground">
           <span className="text-3xl">✨</span>
@@ -59,22 +71,36 @@ export const LocationRequest = ({ onLocationGranted, onLocationDenied, mood, err
           )}
 
           <div className="space-y-3">
-            <Button 
-              variant="action" 
+            <Button
+              variant="action"
               onClick={handleRequestLocation}
               className="w-full h-12"
             >
               <MapPin className="w-4 h-4 mr-2" />
               Share My Location
             </Button>
-            
-            <Button 
-              variant="ghost" 
-              onClick={onLocationDenied}
+
+            <Button
+              variant="ghost"
+              onClick={() => setShowZipInput(true)}
               className="w-full text-muted-foreground"
             >
               I'll enter my ZIP code instead
             </Button>
+
+            {showZipInput && (
+              <form onSubmit={handleZipSubmit} className="flex gap-2 pt-2">
+                <Input
+                  value={zip}
+                  onChange={(e) => setZip(e.target.value)}
+                  placeholder="Enter ZIP code"
+                  className="flex-1"
+                />
+                <Button type="submit" variant="action">
+                  Go
+                </Button>
+              </form>
+            )}
           </div>
 
           <div className="flex items-center gap-2 text-xs text-muted-foreground">

--- a/src/components/RecommendationCard.tsx
+++ b/src/components/RecommendationCard.tsx
@@ -31,7 +31,7 @@ export const RecommendationCard = ({
   };
 
   return (
-    <div className="min-h-screen bg-background flex flex-col items-center justify-center p-6">
+    <div className="min-h-screen flex flex-col items-center justify-center p-6">
       <div className="max-w-md w-full space-y-6">
         <div className="text-center">
           <p className="text-lg text-muted-foreground mb-2 flex items-center justify-center gap-2">

--- a/src/utils/location.ts
+++ b/src/utils/location.ts
@@ -58,6 +58,29 @@ export const getCurrentLocation = (): Promise<UserLocation> => {
   });
 };
 
+export const getLocationFromZip = async (zip: string): Promise<UserLocation> => {
+  let country = "us";
+  let code = zip.trim();
+  const parts = code.split(/\s+/);
+  if (parts.length > 1 && /^[a-zA-Z]{2,}$/i.test(parts[0])) {
+    country = parts[0].toLowerCase();
+    code = parts.slice(1).join(" ");
+  }
+
+  const response = await fetch(`https://api.zippopotam.us/${country}/${encodeURIComponent(code)}`);
+  if (!response.ok) {
+    throw new Error("Invalid ZIP code");
+  }
+  const data = await response.json();
+  const place = data.places[0];
+  return {
+    latitude: parseFloat(place.latitude),
+    longitude: parseFloat(place.longitude),
+    city: place["place name"],
+    state: place["state abbreviation"] || place.state
+  };
+};
+
 export const getDistanceInMiles = (
   lat1: number,
   lon1: number,


### PR DESCRIPTION
## Summary
- enable users to manually enter any ZIP code and geocode it to a location
- keep animated gradient background visible after vibe selection

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a1b86a12b88328abd03b0bde57c5f9