### PR TITLE
feat: add open-source analytics

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,6 +23,11 @@
       href="https://fonts.googleapis.com/css2?family=Poppins:wght@600;800&display=swap"
       rel="stylesheet"
     />
+    <script
+      defer
+      data-domain="vibepick.app"
+      src="https://plausible.io/js/script.js"
+    ></script>
   </head>
 
   <body>

--- a/index.html
+++ b/index.html
@@ -23,11 +23,7 @@
       href="https://fonts.googleapis.com/css2?family=Poppins:wght@600;800&display=swap"
       rel="stylesheet"
     />
-    <script
-      defer
-      data-domain="vibepick.app"
-      src="https://plausible.io/js/script.js"
-    ></script>
+    <script defer data-domain="vibepick.shreyasrk.com" src="https://plausible.io/js/script.js"></script>
   </head>
 
   <body>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import { Toaster } from "@/components/ui/toaster";
 import { Toaster as Sonner } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
@@ -5,23 +6,30 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Index from "./pages/Index";
 import NotFound from "./pages/NotFound";
+import { trackEvent } from "@/lib/analytics";
 
 const queryClient = new QueryClient();
 
-const App = () => (
-  <QueryClientProvider client={queryClient}>
-    <TooltipProvider>
-      <Toaster />
-      <Sonner />
-      <BrowserRouter>
-        <Routes>
-          <Route path="/" element={<Index />} />
-          {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
-          <Route path="*" element={<NotFound />} />
-        </Routes>
-      </BrowserRouter>
-    </TooltipProvider>
-  </QueryClientProvider>
-);
+const App = () => {
+  useEffect(() => {
+    trackEvent("pageview");
+  }, []);
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      <TooltipProvider>
+        <Toaster />
+        <Sonner />
+        <BrowserRouter>
+          <Routes>
+            <Route path="/" element={<Index />} />
+            {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
+            <Route path="*" element={<NotFound />} />
+          </Routes>
+        </BrowserRouter>
+      </TooltipProvider>
+    </QueryClientProvider>
+  );
+};
 
 export default App;

--- a/src/components/MoodBoard.tsx
+++ b/src/components/MoodBoard.tsx
@@ -1,6 +1,7 @@
 import { useState, useRef, type CSSProperties } from "react";
 import { Button } from "@/components/ui/button";
 import confetti from "canvas-confetti";
+import { trackEvent } from "@/lib/analytics";
 
 interface Mood {
   id: string;
@@ -110,12 +111,14 @@ export const MoodBoard = ({ onMoodSelect }: MoodBoardProps) => {
     setTimeout(() => {
       mascotRef.current?.classList.remove("animate-bounce");
       setAnimating(null);
+      trackEvent("mood_selected", { mood: mood.id });
       onMoodSelect(mood.id);
     }, 600);
   };
 
   const handleSurprise = () => {
     if (rolling) return;
+    trackEvent("surprise_me_clicked");
     setGuideText("Rolling the dice...");
     const finalMood = moods[Math.floor(Math.random() * moods.length)];
     const items = Array.from({ length: 8 }, () => moods[Math.floor(Math.random() * moods.length)].label);
@@ -129,6 +132,7 @@ export const MoodBoard = ({ onMoodSelect }: MoodBoardProps) => {
       setSlotAnimating(false);
       setRolling(false);
       setSlotItems(["Surprise Me"]);
+      trackEvent("pageview");
       handleMoodClick(finalMood);
     }, 1000);
   };
@@ -229,6 +233,7 @@ export const MoodBoard = ({ onMoodSelect }: MoodBoardProps) => {
               href={todayPick.link}
               target="_blank"
               className="block bg-gradient-card p-4 rounded-lg shadow-card-custom hover:shadow-lg transition-shadow"
+              onClick={() => trackEvent("daily_pick_clicked")}
             >
               <p className="text-sm text-muted-foreground">{todayPick.text}</p>
             </a>

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,0 +1,11 @@
+export const trackEvent = (name: string, options?: Record<string, unknown>) => {
+  window.plausible?.(name, { props: options });
+};
+
+declare global {
+  interface Window {
+    plausible?: (name: string, options?: { props?: Record<string, unknown> }) => void;
+  }
+}
+
+export {}; // Ensure this file is treated as a module


### PR DESCRIPTION
## Summary
- load Plausible analytics script
- track page views and engagement events via helper

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a211410e288328aa3c9a34b66a4b1b